### PR TITLE
Change protocol and port number

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,7 +20,7 @@ function App() {
   return (
     <div className="App">
       <header className="App-header">
-        <img alt="ejemplo" src={`https://127.0.0.1/ipfs/${record}`} />
+        <img alt="ejemplo" src={`http://127.0.0.1:8080/ipfs/${record}`} />
       </header>
     </div>
   );


### PR DESCRIPTION
@ivanci0 I cloned your repo and tried to make the image to display but I got a ERR:REFUSED or ERR:SSL certificate error.
So finally I made it work by not using `https` and using as port as default the `port` 8080.
Eventually this could be an option.. If another port is being used..

Please let me know if you agree with this changes or if I missed something..

Cheers
Sebastian